### PR TITLE
Allow to configure the host HW values

### DIFF
--- a/host_scripts/setup-env.sh
+++ b/host_scripts/setup-env.sh
@@ -48,9 +48,9 @@ EOS
 
 function create_host {
   local NAME=${1:-"$CLUSTER_NAME"}
-  local DISKGIB=121
-  local MEMMIB=33
-  local CPUS=8
+  local DISKGIB=${2:-121}
+  local MEMMIB=${3:-33}
+  local CPUS=${4:-8}
 
   if [[ $DEBUG -eq $TRUE ]]
   then
@@ -81,7 +81,7 @@ function create_masters {
 
   for i in $(seq "$N")
   do
-    create_host "$CLUSTER_NAME-$i" $((MASTER_DISKGIB + i)) "$MASTER_MEMMIB" "$MASTER_CPUS"
+    create_host "$CLUSTER_NAME-$i" "$MASTER_DISKGIB" "$MASTER_MEMMIB" "$MASTER_CPUS"
   done
 }
 
@@ -90,7 +90,7 @@ function create_workers {
 
   for i in $(seq "$N")
   do
-    create_host "$CLUSTER_NAME-worker-$i" $((WORKER_DISKGIB + i)) "$WORKER_MEMMIB" "$WORKER_CPUS"
+    create_host "$CLUSTER_NAME-worker-$i" "$WORKER_DISKGIB" "$WORKER_MEMMIB" "$WORKER_CPUS"
   done
 }
 


### PR DESCRIPTION
The HW properties being passed as environment variables were ignored.

Now we can specify the values for the Masters and Workers differently, 

eg.

```
MASTER_DISKGIB=10 MASTER_MEMMIB=8 MASTER_CPUS=4 WORKER_DISKGIB=10 WORKER_MEMMIB=3 WORKER_CPUS=2 ./setup-env.sh --cluster-name=cluster-name --num-of-nodes=3 --with-workers --debug discovery-image.iso

```